### PR TITLE
Add storage mechnism for extension result

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ hypha
 tqdm
 aiofiles
 langchain==0.0.335
+datamodel-code-generator


### PR DESCRIPTION
Add a storage manager to store the results of extensions in a dict, allowing for data exchange between different extensions.

ImJoy plugin for test the storage: https://gist.githubusercontent.com/Nanguage/bde31a2f3dc1973d68537349825e25d9/raw/fc6775b0d4bbed432cd19a3638e8cd927af99220/chatbot-launcher.imjoy.html