### PR TITLE
add python console and web client extensions

### DIFF
--- a/bioimageio_chatbot/chatbot_extensions/docs_extension.py
+++ b/bioimageio_chatbot/chatbot_extensions/docs_extension.py
@@ -85,7 +85,7 @@ def get_extensions():
     docs_store_dict = load_knowledge_base(knowledge_base_path)
     return [
         ChatbotExtension(
-            name=collection["id"],
+            name=collection["id"]+"(docs)",
             description=collection["description"],
             get_schema=partial(get_schema, collection),
             execute=partial(run_extension, docs_store_dict, collection["id"]),

--- a/bioimageio_chatbot/static/index.html
+++ b/bioimageio_chatbot/static/index.html
@@ -501,6 +501,28 @@
         },
       });
 
+      app.addMenuItem({
+        label: "Enable PythonConsole",
+        async callback() {
+          const uri = prompt(
+              `Please type a ImJoy plugin URL`,
+              "https://nanguage.github.io/web-python-console/chatbot-extension.imjoy.html"
+          );
+          if (uri) app.loadPlugin(uri);
+        },
+      });
+
+      app.addMenuItem({
+        label: "Enable BioengineWebClient",
+        async callback() {
+          const uri = prompt(
+              `Please type a ImJoy plugin URL`,
+              "https://bioimage-io.github.io/bioengine-web-client/chatbot-extension.imjoy.html"
+          );
+          if (uri) app.loadPlugin(uri);
+        },
+      });
+
       const api = app.imjoy.api
       app.addMenuItem({
         label: "Enable ImageJMacro",


### PR DESCRIPTION
1. Add [web-python-console](https://github.com/Nanguage/web-python-console) and [bioengine-web-client](https://github.com/bioimage-io/bioengine-web-client) to app menu.
2. Add `(docs)` to the name of document retrieval extensions for differentiate from other extensions.