### PR TITLE
Avoid 0 height window

### DIFF
--- a/bioimageio_chatbot/static/index.html
+++ b/bioimageio_chatbot/static/index.html
@@ -202,6 +202,10 @@
       margin: 0 auto;
       /* Center the chat container horizontally */
     }
+    .window {
+      /* Avoid window with 0 height */
+      min-height: 220px !important;
+    }
 
 
 


### PR DESCRIPTION
Fix the bug of 0 height window, when chatbot call the extension. My environment: windows10, Chrome browser

![zero-height](https://github.com/bioimage-io/bioimageio-chatbot/assets/14010939/3694bbee-8468-4d90-868e-7b264b23a4a6)
