### PR TITLE
Fix cell image links in HPA extension

### DIFF
--- a/bioimageio_chatbot/chatbot_extensions/hpa_extension.py
+++ b/bioimageio_chatbot/chatbot_extensions/hpa_extension.py
@@ -62,13 +62,13 @@ class HPAClient:
 
 
     async def get_cell_image(self,
-        gen: str = Field(..., description="Gene name of the protein."),
+        gene: str = Field(..., description="Gene name of the protein."),
         ensembl: str = Field(..., description="Ensembl ID of the protein."),
         section: str = Field("subcellular", description="Section of the Human Protein Atlas to search for the protein. Valid options are 'subcellular', 'tissue',")
         ) -> List[str]:
         """Retrieve a list of cell image links from the Human Protein Atlas, where a specific protein is tagged in the green channel. 
         ALWAYS render the result thumbnail images as a horizatal table and create link (format: `[![](http://..._thumb.jpg)](http://....jpg)`) to the full-size image without the '_thumb' suffix."""
-        link_name = f"{ensembl}-{gen}"
+        link_name = f"{ensembl}-{gene}"
         http_link = f"https://www.proteinatlas.org/{link_name}/{section}"
         # read the source code of the page
         response = requests.get(http_link)

--- a/bioimageio_chatbot/chatbot_extensions/hpa_extension.py
+++ b/bioimageio_chatbot/chatbot_extensions/hpa_extension.py
@@ -75,11 +75,10 @@ class HPAClient:
         if '<p>Not available</p>' in response.text:
             return 'No cell image available.'
         # Search for image links, capturing the part after 'src="'
-        pattern = r'src="(?P<url>//images\.proteinatlas\.org/.*?_blue_red_green_thumb\.jpg)"'
+        pattern = r'src="(?P<url>//images\.proteinatlas\.org/.*?_red_green_thumb\.jpg)"'
         image_links = re.findall(pattern, response.text)
-        
-        # replace the 'red_green' with 'blue_red_green_yellow' 
-        image_links = [link.replace('blue_red_green', 'blue_red_green_yellow') for link in image_links]
+        # replace the 'red_green' with 'blue_red_green_yellow' if 'blue' not in the link, otherwise replace 'blue_red_green' with 'blue_red_green_yellow'
+        image_links = [link.replace('red_green', 'blue_red_green_yellow') if 'blue' not in link else link.replace('blue_red_green', 'blue_red_green_yellow') for link in image_links]
         # Remove '_thumb' from each link and print or process them
         final_image_links = []
         for link in image_links:

--- a/bioimageio_chatbot/chatbot_extensions/hpa_extension.py
+++ b/bioimageio_chatbot/chatbot_extensions/hpa_extension.py
@@ -67,7 +67,7 @@ class HPAClient:
         section: str = Field("subcellular", description="Section of the Human Protein Atlas to search for the protein. Valid options are 'subcellular', 'tissue',")
         ) -> List[str]:
         """Retrieve a list of cell image links from the Human Protein Atlas, where a specific protein is tagged in the green channel. 
-        The results SHOULD BE rendered as a horizatal table of images and create link (format: `[![](http://..._thumb.jpg)](http://....jpg)`) to the full-size image without the '_thumb' suffix."""
+        ALWAYS render the result thumbnail images as a horizatal table and create link (format: `[![](http://..._thumb.jpg)](http://....jpg)`) to the full-size image without the '_thumb' suffix."""
         link_name = f"{ensembl}-{gen}"
         http_link = f"https://www.proteinatlas.org/{link_name}/{section}"
         # read the source code of the page
@@ -96,7 +96,7 @@ def get_extension():
     return ChatbotExtension(
         id="hpa",
         name="Human Protein Atlas",
-        description="Search the Human Protein Atlas to find human protein-related information, including gene expressions, functions, locations, disease associations, and cell images etc. WHen searching for cell images, always search for the gene name and Ensembl ID of the protein.",
+        description="Search the Human Protein Atlas to find human protein-related information, including gene expressions, functions, locations, disease associations, and cell images etc. When searching for cell images, always search for the gene name and Ensembl ID of the protein.",
         tools=dict(
             search=search_tool,
             read=read_tool,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "bioimageio-chatbot"
-version = "0.2.1"
+version = "0.2.2"
 readme = "README.md"
 description = "Your Personal Assistant in Computational BioImaging."
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "bioimageio-chatbot"
-version = "0.2.4"
+version = "0.2.5"
 readme = "README.md"
 description = "Your Personal Assistant in Computational BioImaging."
 dependencies = [


### PR DESCRIPTION
Cell image links are not correctly extracted, e.g., link is given as "https://images.proteinatlas.org/4840/1852_D3_20_cr5afd37edbb5e8_blue_blue_red_green_yellow_thumb.jpg" while the correct linke sould be "https://images.proteinatlas.org/4840/1852_D3_20_cr5afd37edbb5e8_blue_red_green_yellow_thumb.jpg".
Fix the implementation for HPA extension to extract links by expression r'src="(?P<url>//images\.proteinatlas\.org/.*?_blue_red_green_thumb\.jpg)"', then replace 'blue_red_green' to 'blue_red_green_yellow' to get all channels.